### PR TITLE
Remove test with spaces in type-brackets

### DIFF
--- a/tester/testsuite/extensions/arrays1/array007.jl
+++ b/tester/testsuite/extensions/arrays1/array007.jl
@@ -1,6 +1,0 @@
-int main() {
-    int[]x;
-    int [       ] y;
-    int[ ]z;
-    return 0;
-}


### PR DESCRIPTION
The aim of this PR is to simplify the syntax for array types a bit. Previously, your parser would have to deal with array brackets as separate tokens, e.g.: `int [    ] x;`. Now, you can assume that all array type brackets come as one token: `int [] x;`.