### PR TITLE
Add WASM WASI backend

### DIFF
--- a/tester/README.md
+++ b/tester/README.md
@@ -34,6 +34,7 @@ The following command line options are available:
 | `    --x64`                   | Test the 64-bit x86 backend           |
 | `    --riscv`                 | Test the RISC-V backend               |
 | `    --wasm`                  | Test the WASM JS backend              |
+| `    --wasm-wasi`             | Test the WASM WASI backend            |
 | `-x <ext> [ext ...]`          | Test one or more extensions           |
 | `    --noclean`               | Do not clean up temporary files       |
 


### PR DESCRIPTION
The WASM WASI backend executes WASM directly in a VM, with access to the OS, instead of through Javascript.
The component model is used to compose a runtime with the Javalette program.

Note: I didn't get Docker running for this repo in the first place, so I only tested this locally on my Apple Silicon machine.

## Tools required

- `wasm-tools`
- `wac`
- `wasmtime`

## Setup

The tools expect the `runtime.wasm` to be a component.
The interface descriptions should be located in a folder named `wit` (relative to the path provided).
The wit file for the Javalette program must be located in the root of the `wit` dir and must contain a world named `program`.
The wit files for the runtime and its dependencies must be located in `wit/deps/`. It is advised to fetch them with the tool `wit-deps` to get the right files in the right places.